### PR TITLE
Fix compiling err

### DIFF
--- a/surround360_render/source/test/TestColorCalibration.cpp
+++ b/surround360_render/source/test/TestColorCalibration.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <iostream>
+#include <iterator>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
To fix compiling err:
source/test/TestColorCalibration.cpp:119:52: error: ‘istream_iterator’ is not a membe
r of ‘std’