### PR TITLE
Add header file for iterator

### DIFF
--- a/surround360_render/source/test/TestColorCalibration.cpp
+++ b/surround360_render/source/test/TestColorCalibration.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <iterator>
 
 #include "CameraIsp.h"
 #include "ColorCalibration.h"


### PR DESCRIPTION
Used to throw this error while compiling using g++ 4.8.4 on Ubuntu 14.04:
"error: ‘istream_iterator’ is not a member of ‘std’"

Including header file fixes this.