### PR TITLE
Fix isp calculating time

### DIFF
--- a/surround360_render/source/util/SystemUtil.h
+++ b/surround360_render/source/util/SystemUtil.h
@@ -58,7 +58,7 @@ static void requireArgGeqZero(const int& argValue, const string& argName) {
 
 // return the current system time in seconds. reasonably high precision.
 static double getCurrTimeSec() {
-  return (double)(system_clock::now().time_since_epoch().count()) / 1000000.0;
+  return (double)(system_clock::now().time_since_epoch().count()) * system_clock::period::num / system_clock::period::den;
 }
 
 // scans srcDir for all files/folders, and return a vector of filenames (or full file


### PR DESCRIPTION
Fix isp calculating time on Ubuntu 16.04.

It seems that ```system_clock::now().time_since_epoch().count()``` is depend on platform.