### PR TITLE
Update PixFlow.h, fix vertical regularization error term

### DIFF
--- a/surround360_render/source/optical_flow/PixFlow.h
+++ b/surround360_render/source/optical_flow/PixFlow.h
@@ -516,7 +516,7 @@ struct PixFlow : public OpticalFlowInterface {
 
     float err = sqrtf((i0x - i1x) * (i0x - i1x) + (i0y - i1y) * (i0y - i1y))
       + smoothness * smoothnessCoef
-      + verticalRegularizationCoef * fabsf(flowDir.y) / float(I0.cols)
+      + verticalRegularizationCoef * fabsf(flowDir.y) / float(I0.rows)
       + horizontalRegularizationCoef * fabsf(flowDir.x) / float(I0.cols);
 
     if (UseDirectionalRegularization) {


### PR DESCRIPTION
vertical regularization error term should use variable 'I0.rows' instead of 'I0.cols' to make sense.