### PR TITLE
Updated to make the 4k output square

### DIFF
--- a/surround360_render/scripts/batch_process_video.py
+++ b/surround360_render/scripts/batch_process_video.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
       render_params["EQR_WIDTH"]                    = 4200
       render_params["EQR_HEIGHT"]                   = 1024
       render_params["FINAL_EQR_WIDTH"]              = 4096
-      render_params["FINAL_EQR_HEIGHT"]             = 2048
+      render_params["FINAL_EQR_HEIGHT"]             = 4096
     elif quality == "6k":
       render_params["SHARPENNING"]                  = 0.25
       render_params["EQR_WIDTH"]                    = 6300


### PR DESCRIPTION
4k option was creating a 4kx2k file instead of a square file (4096x4096)