### PR TITLE
written error in TestVignettingCalibration.cpp

### DIFF
--- a/surround360_render/source/test/TestVignettingCalibration.cpp
+++ b/surround360_render/source/test/TestVignettingCalibration.cpp
@@ -382,7 +382,7 @@ int main(int argc, char** argv) {
 
     cameraIspTest.setup();
     cameraIspTest.loadImage(rawTest);
-    cameraIsp.getImage(rawTestIspOut);
+    cameraIspTest.getImage(rawTestIspOut);
     const string rawTestIspOutFilename = outputDir + "/test_out_rgb.png";
     imwriteExceptionOnFail(rawTestIspOutFilename, rawTestIspOut);
   }


### PR DESCRIPTION
in TestVignettingCalibration.cpp , line 385:
cameraIsp.getImage(rawTestIspOut)
should be cameraIspTest.getImage(rawTestIspOut)?