### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/surround360_design/CONTRIBUTING.md
+++ b/surround360_design/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We want to make contributing to this project as easy and transparent as
 possible.
 
 ## Code of Conduct
-The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).
 
 ## Our Development Process
 

--- a/surround360_design/CONTRIBUTING.md
+++ b/surround360_design/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 
 We maintain a repository for Surround 360 using Facebook's internal infrastructure, which is automatically synched with GitHub.

--- a/surround360_render/CONTRIBUTING.md
+++ b/surround360_render/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We want to make contributing to this project as easy and transparent as
 possible.
 
 ## Code of Conduct
-The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).
 
 ## Our Development Process
 

--- a/surround360_render/CONTRIBUTING.md
+++ b/surround360_render/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 
 We maintain a repository for Surround 360 using Facebook's internal infrastructure, which is automatically synched with GitHub.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Surround360 community profile
checklist](https://github.com/facebook/Surround360/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
<img width="1006" alt="screen shot 2017-12-20 at 7 57 00 am" src="https://user-images.githubusercontent.com/1114467/34217916-a569e68e-e561-11e7-9dc3-849da4e4a5fa.png">
![screen shot 2017-12-20 at 8 38 58 am](https://user-images.githubusercontent.com/1114467/34217917-a585802e-e561-11e7-8ab1-00fec640c221.png)

issue:
internal task t23481323